### PR TITLE
feat: add deployment_oom_finding action

### DIFF
--- a/event_enrichment/deployment_finding.py
+++ b/event_enrichment/deployment_finding.py
@@ -47,12 +47,20 @@ def create_deployment_finding(event: PodEvent, params: DeploymentFindingParams):
         labels=labels,
     )
 
-    # Simple title templating
+    # Title templating with fallbacks
     title = params.title
+    title = title.replace("$deployment", deployment_name)
     title = title.replace("$name", pod.metadata.name)
     title = title.replace("$namespace", pod.metadata.namespace)
+    
+    # Replace label placeholders, with fallback to deployment_name for missing labels
     for key, value in labels.items():
         title = title.replace(f"$labels.{key}", str(value))
+    
+    # Fallback: if $labels.X still in title (label was missing), use deployment_name
+    if "$labels." in title:
+        import re
+        title = re.sub(r"\$labels\.\w+", deployment_name, title)
 
     event.add_finding(
         Finding(

--- a/event_enrichment/deployment_finding.py
+++ b/event_enrichment/deployment_finding.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from robusta.api import (
     ActionParams,
     Finding,
@@ -9,20 +11,24 @@ from robusta.api import (
 )
 
 
-class DeploymentOOMParams(ActionParams):
+class DeploymentFindingParams(ActionParams):
     """
     :var title: Finding title (supports $name, $namespace, $labels.X templating)
     :var aggregation_key: Key for grouping alerts
+    :var severity: Finding severity (DEBUG, INFO, LOW, HIGH). Default: HIGH
     """
-    title: str = "Deployment OOM - $labels.service"
-    aggregation_key: str = "DeploymentOOM"
+    title: str = "$labels.service"
+    aggregation_key: str = "DeploymentFinding"
+    severity: str = "HIGH"
 
 
 @action
-def deployment_oom_finding(event: PodEvent, params: DeploymentOOMParams):
+def create_deployment_finding(event: PodEvent, params: DeploymentFindingParams):
     """
-    Create an OOM finding grouped by deployment instead of pod.
-    Uses the 'service' label as the deployment identifier.
+    Create a finding grouped by deployment instead of pod.
+    
+    Uses the 'service' label (or 'app' as fallback) as the deployment identifier.
+    This changes the fingerprint so alerts from the same deployment are grouped together.
     """
     pod = event.get_pod()
     if not pod:
@@ -52,9 +58,8 @@ def deployment_oom_finding(event: PodEvent, params: DeploymentOOMParams):
         Finding(
             title=title,
             aggregation_key=params.aggregation_key,
-            severity=FindingSeverity.HIGH,
+            severity=FindingSeverity.from_severity(params.severity),
             subject=subject,
             source=event.get_source(),
         )
     )
-

--- a/event_enrichment/deployment_oom_finding.py
+++ b/event_enrichment/deployment_oom_finding.py
@@ -1,0 +1,60 @@
+from robusta.api import (
+    ActionParams,
+    Finding,
+    FindingSeverity,
+    FindingSubject,
+    FindingSubjectType,
+    PodEvent,
+    action,
+)
+
+
+class DeploymentOOMParams(ActionParams):
+    """
+    :var title: Finding title (supports $name, $namespace, $labels.X templating)
+    :var aggregation_key: Key for grouping alerts
+    """
+    title: str = "Deployment OOM - $labels.service"
+    aggregation_key: str = "DeploymentOOM"
+
+
+@action
+def deployment_oom_finding(event: PodEvent, params: DeploymentOOMParams):
+    """
+    Create an OOM finding grouped by deployment instead of pod.
+    Uses the 'service' label as the deployment identifier.
+    """
+    pod = event.get_pod()
+    if not pod:
+        return
+
+    labels = pod.metadata.labels or {}
+
+    # Get deployment name from labels (try common patterns)
+    deployment_name = labels.get("service") or labels.get("app") or pod.metadata.name
+
+    # Create subject with deployment name instead of pod name
+    subject = FindingSubject(
+        name=deployment_name,
+        subject_type=FindingSubjectType.TYPE_DEPLOYMENT,
+        namespace=pod.metadata.namespace,
+        labels=labels,
+    )
+
+    # Simple title templating
+    title = params.title
+    title = title.replace("$name", pod.metadata.name)
+    title = title.replace("$namespace", pod.metadata.namespace)
+    for key, value in labels.items():
+        title = title.replace(f"$labels.{key}", str(value))
+
+    event.add_finding(
+        Finding(
+            title=title,
+            aggregation_key=params.aggregation_key,
+            severity=FindingSeverity.HIGH,
+            subject=subject,
+            source=event.get_source(),
+        )
+    )
+


### PR DESCRIPTION
## Summary
Custom action that creates OOM findings grouped by **deployment** instead of **pod**.

## How it works
- Uses the `service` label (or `app` label as fallback) as the deployment identifier
- Sets `subject.name` to deployment name instead of pod name
- Sets `subject_type` to `deployment` instead of `pod`

This changes the fingerprint calculation so all OOM alerts from the same deployment are grouped together in JSM/OpsGenie.

## Usage
```yaml
customPlaybooks:
  - triggers:
      - on_pod_oom_killed: {}
    actions:
      - deployment_oom_finding: {}
      - pod_oom_killed_enricher: {}
```

## Related PR
- cyeragit/cyera-flux#15545 (depends on this PR)